### PR TITLE
Block web crawlers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ loris_prefix: loris # URI path prefix before the image identifier
 loris_log_level: INFO # DEBUG|INFO|WARNING|ERROR|CRITICAL
 loris_log_max_size: 52428800 # 50 MB
 loris_log_max_backups: 5
+loris_block_robots: yes

--- a/files/www/loris2/robots.txt
+++ b/files/www/loris2/robots.txt
@@ -1,0 +1,1 @@
+User-agent: * Disallow: /

--- a/tasks/loris_install.yml
+++ b/tasks/loris_install.yml
@@ -37,9 +37,16 @@
     - /opt/loris/loris/data/www/*
   tags: loris_files
 
+- name: copy robots.txt
+  copy:
+    src: files/www/loris2/robots.txt
+    dest: /var/www/loris2/public/
+  tags: loris_files
+  when: loris_block_robots
+
 - name: copy loris2.wsgi
   copy:
-    src: files/www/loris2/
+    src: files/www/loris2/loris2.wsgi
     dest: /var/www/loris2/
   tags: loris_files
 

--- a/templates/apache.conf.j2
+++ b/templates/apache.conf.j2
@@ -52,7 +52,8 @@
     # Tell apache we're on HTTPS if reverse proxy is serving the site using SSL
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
-    # Block a few common web crawlers
+    {% if loris_block_robots %}
+    # Block common web crawlers from overloading loris
     BrowserMatchNoCase Googlebot is_robot
     BrowserMatchNoCase bingbot is_robot
     BrowserMatchNoCase SemrushBot is_robot
@@ -62,5 +63,6 @@
         allow from all
         deny from env=is_robot
     </Location>
+    {% endif %}
 
 </VirtualHost>

--- a/templates/apache.conf.j2
+++ b/templates/apache.conf.j2
@@ -52,4 +52,15 @@
     # Tell apache we're on HTTPS if reverse proxy is serving the site using SSL
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
+    # Block a few common web crawlers
+    BrowserMatchNoCase Googlebot is_robot
+    BrowserMatchNoCase bingbot is_robot
+    BrowserMatchNoCase SemrushBot is_robot
+    BrowserMatchNoCase Baiduspider is_robot
+    <Location /loris>
+        Order allow,deny
+        allow from all
+        deny from env=is_robot
+    </Location>
+
 </VirtualHost>


### PR DESCRIPTION
This PR adds an option to block web crawlers that can sometimes overload the server.

**Changes:**
- Added ansible role variable `loris_block_robots` that is enabled by default.
- Added `robots.txt` to advise robots not to crawl the site.
- Updated apache so that if the `User-Agent` header matches a blacklisted bot, it will be denied access (e.g. return 403).

**Testing:**

```
$ curl --head --user-agent "Googlebot/2.1 (+http://www.google.com/bot.html)" https://<SERVER>/loris
HTTP/2 403
date: Tue, 07 Sep 2021 18:28:32 GMT
content-type: text/html; charset=iso-8859-1
server: Apache/2.4.29 (Ubuntu)

$ curl --head https://<SERVER>/loris
HTTP/2 301
date: Tue, 07 Sep 2021 18:31:04 GMT
content-type: text/html; charset=iso-8859-1
server: Apache/2.4.29 (Ubuntu)
...

$ curl https://<SERVER>/robots.txt
User-agent: * Disallow: /
```


