### PR TITLE
Add libffi-dev for ubuntu22.04

### DIFF
--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -24,6 +24,7 @@
       - liblcms2-utils
       - libtiff5-dev
       - libwebp-dev
+      - libffi-dev
   tags: apt
 
 - name: create loris group


### PR DESCRIPTION
This PR ensures that `libffi-dev` package is installed for Ubuntu 22.04 compatibility.