### PR TITLE
Fix: install loris into python venv to avoid breaking system packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ wsgi_maximum_requests: 1000
 wsgi_graceful_timeout: 30
 wsgi_restart_interval: 86400
 apache_log_level: 'info'
+loris_venv_path: /opt/loris-venv

--- a/files/www/loris2/loris2.wsgi
+++ b/files/www/loris2/loris2.wsgi
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
 from loris.webapp import create_app
 
-# Uncomment and configure below if you are using virtualenv
-# import site
-# site.addsitedir('/path/to/my/virtualenv/lib/python2.x/site-packages')
-
 application = create_app(config_file_path='/etc/loris2/loris2.conf')

--- a/tasks/loris_install.yml
+++ b/tasks/loris_install.yml
@@ -14,11 +14,13 @@
 #   args:
 #     chdir: /opt/loris
 
-- name: pip install loris 
+- name: pip install loris
   pip:
     name: "/opt/loris"
     editable: no
     extra_args: "--upgrade"
+    virtualenv: "{{ loris_venv_path }}"
+    virtualenv_command: python3 -m venv
   register: loris_updated
   tags: pip
 

--- a/tasks/loris_install.yml
+++ b/tasks/loris_install.yml
@@ -24,6 +24,14 @@
   register: loris_updated
   tags: pip
 
+- name: upgrade urllib3 in loris venv
+  pip:
+    name: "urllib3>=1.26"
+    extra_args: "--upgrade"
+    virtualenv: "{{ loris_venv_path }}"
+    virtualenv_command: python3 -m venv
+  tags: pip
+
 - name: ensure document root exists
   file:
     path: /var/www/loris2/public

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -10,6 +10,7 @@
       - python3-pip
       - python3-dev
       - python3-setuptools
+      - python3-venv
   tags: apt
 
 - name: install required image libraries

--- a/templates/apache.conf.j2
+++ b/templates/apache.conf.j2
@@ -35,7 +35,7 @@
 
     AllowEncodedSlashes On
     
-    WSGIDaemonProcess loris2 user=loris group=loris processes={{ wsgi_processes }} threads={{ wsgi_threads }} maximum-requests={{ wsgi_maximum_requests }} graceful-timeout={{ wsgi_graceful_timeout }} restart-interval={{ wsgi_restart_interval }}
+    WSGIDaemonProcess loris2 user=loris group=loris processes={{ wsgi_processes }} threads={{ wsgi_threads }} maximum-requests={{ wsgi_maximum_requests }} graceful-timeout={{ wsgi_graceful_timeout }} restart-interval={{ wsgi_restart_interval }} python-home={{ loris_venv_path }}
     WSGIProcessGroup loris2
     WSGIScriptAlias /loris /var/www/loris2/loris2.wsgi
 


### PR DESCRIPTION
## Overview

This PR installs Loris into a virtual env (`/opt/loris-venv`) so its dependencies never conflict with system packages. This resolves a `cloud-init` boot issue with `urllib3` that manifests with an error like this:

```
ImportError: cannot import name 'Mapping' from 'collections' 
    (/usr/lib/python3.10/collections/__init__.py)
```

## Changes

- Installed `python3-venv` apt package
- Installed Loris into the venv using Ansible's [pip virtualenv](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html#parameter-virtualenv) parameter.
- Added `loris_venv_path` default variable
- Added `python-home` to `WSGIDaemonProcess` so mod_wsgi loads packages from the venv

## Notes

On Ubuntu 22.04 (python 3.10), `pip install /opt/loris` installs Loris's dependencies system-wide, overwriting`urllib3` with an older version that uses `collections.Mapping` ([removed in Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#removed)). This breaks `cloud-init` and other system tools at boot, which  ffectively causes the server to hang after launching and get stuck in the `Initializing...` state.

Apache is configured to use the venv via mod_wsgi's [python-home](https://modwsgi.readthedocs.io/en/master/configuration-directives/WSGIDaemonProcess.html#python-home) directive.

## Testing

- Ensure loris packages end up in `/opt/loris-venv/lib/python3.x/site-packages/`, not `/usr/local/lib/python3.x/dist-packages/`
- The system-wide version of `urllib3` should be untouched (`python3 -c "import urllib3; print(urllib3.__file__)"` should output `/usr/lib/python3/dist-packages/...`)